### PR TITLE
Suppress erronous 'onButtonScanningStopped' callback on scan start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ At this time, there is no background service to keep the service alive and callb
 ### Change the minSdkVersion for Android
 
 Flic2 buttons are compatible only from version 19 of Android SDK so you should change this in **android/app/build.gradle**:
-```dart
+```groovy
 Android {
   defaultConfig {
      minSdkVersion: 19

--- a/android/src/main/java/uk/co/darkerwaters/flic_button/Flic2Controller.java
+++ b/android/src/main/java/uk/co/darkerwaters/flic_button/Flic2Controller.java
@@ -20,6 +20,8 @@ public class Flic2Controller {
 
     private final ButtonCallback callback;
 
+    private boolean isCurrentlyScanning = false;
+
     public interface ButtonCallback {
         void onPairedButtonFound(Flic2Button button);
         void onButtonFound(Flic2Button button);
@@ -39,10 +41,13 @@ public class Flic2Controller {
     }
 
     public boolean startButtonScanning() {
-        // cancel any previous scan
-        cancelButtonScan();
+        if (isCurrentlyScanning){
+            // cancel any previous scan
+            cancelButtonScan();
+        }
         // and start a new one
         callback.onButtonScanningStarted();
+        isCurrentlyScanning = true;
         Flic2Manager.getInstance().startScan(new Flic2ScanCallback() {
             @Override
             public void onDiscoveredAlreadyPairedButton(Flic2Button button) {
@@ -64,6 +69,7 @@ public class Flic2Controller {
             @Override
             public void onComplete(int result, int subCode, Flic2Button button) {
                 callback.onButtonScanningStopped();
+                isCurrentlyScanning = false;
                 if (result == Flic2ScanCallback.RESULT_SUCCESS) {
                     // The button object can now be used, store this
                     storeButtonData(button);

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip


### PR DESCRIPTION
Added tracking of whether currently scanning. Used to suppress erronous `onButtonScanningStopped` callback when starting a scan.

Fixes #5 