### PR TITLE
Added support for gradle 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "uk.co.darkerwaters.flic_button"
+
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
Gradle 8 needs that namespace declaration to work with Android libraries.
Few people are using Gradle 8 with Flutter but at some point everybody will have to switch...